### PR TITLE
Translate utf8 special chars to URL

### DIFF
--- a/insightly.py
+++ b/insightly.py
@@ -592,6 +592,7 @@ class Insightly():
             raise Exception('parameter method must be GET|DELETE|PUT|UPDATE')
         # generate full URL from base url and relative url
         full_url = self.baseurl + url
+        full_url = urllib.quote(full_url, '/:?$=&%\'')
         
         request = urllib2.Request(full_url)
         if alt_auth is not None:


### PR DESCRIPTION
Fix issue #7 
We can now send to the API a string in utf-8 who look like that : (in getContacts) 
filter = ["FIRST_NAME='Toto'", "LAST_NAME='J\xc3\xa9j\xc3\xa9'"]

\xc3\xa9 = é : string in utf-8
