### PR TITLE
Fix bugs in insightly.py get_all() and __init__()

### DIFF
--- a/import_example.py
+++ b/import_example.py
@@ -11,3 +11,6 @@ def dummy(contact):
     # do something with the contact data, such as check external system
     # to see if this contact has been imported, and if not, import it
     return True
+
+if '__main__' == __name__:
+    main()

--- a/insightly.py
+++ b/insightly.py
@@ -623,18 +623,20 @@ class Insightly():
         Iterates through the entire recordset for an object type, optionally filtered by updated_after_utc,
         returns a list of object IDs if ids_only is True
         """
-        if self.version == 'mobile' or self.version == '2.1':
+        if self.version == 'mobile' or self.version == '2.2':
             done = False
             skip = 0
             top = 100
             results = list()
-            updated_after_utc = string.replace(updated_after_utc,' ','+')
+            if updated_after_utc is not None:
+                updated_after_utc = string.replace(updated_after_utc,' ','+')
             while not done:
                 if updated_after_utc is not None:
                     records = self.search(object_type, 'updated_after_utc=' + updated_after_utc, top=top, skip=skip)
+                    print('Search top ' + str(top) + ' after ' + str(skip) + ' since ' + updated_after_utc + ' found ' + str(len(records)))
                 else:
                     records = self.search(object_type, '', top=top, skip=skip)
-                print('Search top ' + str(top) + ' after ' + str(skip) + ' since ' + updated_after_utc + ' found ' + str(len(records)))
+                    print('Search top ' + str(top) + ' after ' + str(skip) + ' found ' + str(len(records)))
                 skip += top
                 for r in records:
                     if ids_only:

--- a/insightly.py
+++ b/insightly.py
@@ -214,7 +214,7 @@ class Insightly():
         if len(apikey) < 1:
             try:
                 f = open('apikey.txt', 'r')
-                apikey = f.read()
+                apikey = f.read().rstrip()
                 if self.debug:        print('API Key read from disk as ' + apikey)
             except:
                 raise Exception('No API provided on instantiation, and apikey.txt file not found in project directory.')


### PR DESCRIPTION
This fixes insightly/insightly-python#20

Fix a few bugs in get_all() which keep import_example.py from running. Also add a workaround to **init**() to keep the API v2.2 server from throwing 500 errors.
