### PR TITLE
3 small tweaks

### DIFF
--- a/insightly.py
+++ b/insightly.py
@@ -215,6 +215,7 @@ class Insightly():
             try:
                 f = open('apikey.txt', 'r')
                 apikey = f.read().rstrip()
+                f.close()
                 if self.debug:        print('API Key read from disk as ' + apikey)
             except:
                 raise Exception('No API provided on instantiation, and apikey.txt file not found in project directory.')

--- a/insightly.py
+++ b/insightly.py
@@ -757,6 +757,12 @@ class Insightly():
                 return querystring
             else:
                 return ''
+
+    def ownerinfo(self):
+        """
+        :return: dictionary of information about the account owner
+        """
+        return {'name': self.owner_name, 'email': self.owner_email, 'id': self.owner_id}
         
     def printline(self, text):
         if lowercase(text).count('fail') > 0:


### PR DESCRIPTION
Here are a few small tweaks:
- Add `__init__.py` so that this directory can be imported as a Python module.
- Close `apikey.txt` after reading it.
- Re-implement rstrip()-ing the API key after reading it. This change has been overwritten recently.
- Add helper method ownerinfo() which returns the Insightly account owner's name, email address, and contact ID.
